### PR TITLE
try fix openssl quit

### DIFF
--- a/tokio-rustls/tests/early-data.rs
+++ b/tokio-rustls/tests/early-data.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "early-data")]
 
-use std::io::{ self, BufReader, BufRead, Cursor };
+use std::io::{ self, BufRead, BufReader, Cursor };
 use std::process::{ Command, Child, Stdio };
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -73,6 +73,7 @@ async fn test_0rtt() -> io::Result<()> {
         .args(&["-cert", "./tests/end.cert"])
         .args(&["-key", "./tests/end.rsa"])
         .args(&["-port", "12354"])
+        .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .spawn()
         .map(DropKill)?;


### PR DESCRIPTION
Fix #3 

I don't know why... but [`close_accept_socket`](https://github.com/openssl/openssl/blob/4bac25e1115b8c613f9fff12b835aca47e2bdef7/apps/s_server.c#L2759) only call by [`read_from_terminal`](https://github.com/openssl/openssl/blob/4bac25e1115b8c613f9fff12b835aca47e2bdef7/apps/s_server.c#L2514) branch, and this change seems to fix the problem.