### PR TITLE
Auto-generate TLS server certificate for unix platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+.DS_Store

--- a/tokio-native-tls/Cargo.toml
+++ b/tokio-native-tls/Cargo.toml
@@ -33,6 +33,9 @@ cfg-if = "0.1"
 env_logger = { version = "0.6", default-features = false }
 futures = { version = "0.3.0", features = ["async-await"] }
 
+tempfile = "3.1"
+lazy_static = "1.4.0"
+
 [target.'cfg(all(not(target_os = "macos"), not(windows), not(target_os = "ios")))'.dev-dependencies]
 openssl = "0.10"
 

--- a/tokio-native-tls/scripts/generate-certificate.sh
+++ b/tokio-native-tls/scripts/generate-certificate.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -e
+
+cd $1
+
+# prepare config file for root CA generation
+cat <<EOF >> root.cnf
+[ req ]
+distinguished_name = req_dn
+[ req_dn ]
+[ v3_ca ]
+basicConstraints = CA:TRUE
+keyUsage = digitalSignature, nonRepudiation, keyCertSign, cRLSign
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always
+EOF
+
+ROOT_CA_KEY=root-ca.key.pem
+ROOT_CA=root-ca.pem
+ROOT_CA_DER=root-ca.der
+
+echo "Generate root CA key"
+openssl genrsa -out $ROOT_CA_KEY 4096
+
+echo "Generate root CA certificate"
+openssl req -x509 -new -key $ROOT_CA_KEY -out $ROOT_CA -days 365 -SHA256 -subj "/C=AU/ST=Some-State/O=Internet Widgits Pty Ltd" -config root.cnf -extensions v3_ca
+openssl x509 -outform der -in $ROOT_CA -out $ROOT_CA_DER
+
+rm root.cnf
+
+# prepare config file for server certificate generation
+cat <<EOF >> server.cnf
+extendedKeyUsage=serverAuth
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = foobar.com
+EOF
+
+
+SERVER_KEY=server.key.pem
+SERVER_CERT=cert.pem
+SERVER_CERT_DER=cert.der
+IDENTITY=identity.p12
+PASSPHRASE=mypass
+
+echo "Generate server key"
+openssl genrsa -out $SERVER_KEY 4096
+
+echo "Generate server certificate"
+openssl req -out server.csr -key $SERVER_KEY -new -days 365 -SHA256 -subj "/C=AU/ST=Some-State/O=Internet Widgits Pty Ltd/CN=foobar.com"
+openssl x509 -req -days 365 -SHA256 -in server.csr -CA $ROOT_CA -CAkey $ROOT_CA_KEY -CAcreateserial -out $SERVER_CERT -extfile server.cnf
+openssl x509 -outform der -in $SERVER_CERT -out $SERVER_CERT_DER
+
+openssl pkcs12 -export -out $IDENTITY -inkey $SERVER_KEY -in $SERVER_CERT -passout pass:$PASSPHRASE
+
+rm server.csr
+rm server.cnf

--- a/tokio-rustls/tests/early-data.rs
+++ b/tokio-rustls/tests/early-data.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "early-data")]
 
-use futures_util::{ready, future, future::Future};
+use futures_util::{future, future::Future, ready};
 use rustls::ClientConfig;
 use std::io::{self, BufRead, BufReader, Cursor};
 use std::net::SocketAddr;

--- a/tokio-rustls/tests/early-data.rs
+++ b/tokio-rustls/tests/early-data.rs
@@ -1,9 +1,10 @@
 #![cfg(feature = "early-data")]
 
+use futures_util::{ready, future, future::Future};
+use rustls::ClientConfig;
 use std::io::{self, BufRead, BufReader, Cursor};
 use std::net::SocketAddr;
 use std::pin::Pin;
-use std::process::{Child, Command, Stdio};
 use std::process::{Child, Command, Stdio};
 use std::sync::Arc;
 use std::task::{Context, Poll};


### PR DESCRIPTION
Automatically generate TLS server certificate for unix platform for `tokio-native-tls` crate.
Fix macOS Catalina untrusted certificates issue due to changed policies for certificates.

Closes #7 