### PR TITLE
fix(CI): add `--all-features` to cargo clippy

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -71,4 +71,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: --all-features -- -D warnings


### PR DESCRIPTION
When with Cargo 1.43, `cargo clippy` failed, add `--all-features` will let it happy.