### PR TITLE
tokio-rustls: add write_vectored implementation

### DIFF
--- a/tokio-rustls/Cargo.toml
+++ b/tokio-rustls/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["asynchronous", "cryptography", "network-programming"]
 edition = "2018"
 
 [dependencies]
-tokio = "0.3"
+tokio = "0.3.5"
 rustls = "0.19"
 webpki = "0.21"
 
@@ -21,7 +21,7 @@ early-data = []
 dangerous_configuration = ["rustls/dangerous_configuration"]
 
 [dev-dependencies]
-tokio = { version = "0.3", features = ["full"] }
+tokio = { version = "0.3.5", features = ["full"] }
 futures-util = "0.3.1"
 lazy_static = "1"
 webpki-roots = "0.21"


### PR DESCRIPTION
This PR adds a `write_vectored` method to the
`AsyncWrite`/`std::io::Write` adapter used by `tokio-rustls`. This means
that when the wrapped `AsyncWrite` supports vectored writes,
`tokio-rustls` will propagate them correctly. I also factored out some
common code between the various `Write` methods.

Note that ideally, we would also pass through
`Write::is_write_vectored`. However, this method is unstable in the
standard library, and `rustls` doesn't call it anyway. It would be nice
to support it on nightly toolchains so that the overhead of vectored
writes is avoided when the `AsyncWrite` type does not support them, but
this would require an upstream change in `rustls` to add a nightly
feature to enable `is_write_vectored`. I'll look into that, but will
probably land support in a follow-up PR.

Closes #36

Signed-off-by: Eliza Weisman <eliza@buoyant.io>