### PR TITLE
chore: update readme links & badges

### DIFF
--- a/tokio-native-tls/README.md
+++ b/tokio-native-tls/README.md
@@ -1,7 +1,11 @@
-# tokio-tls
+# tokio-native-tls
+[![github actions](https://github.com/tokio-rs/tls/workflows/CI/badge.svg)](https://github.com/tokio-rs/tls/actions)
+[![crates](https://img.shields.io/crates/v/tokio-native-tls.svg)](https://crates.io/crates/tokio-native-tls)
+[![license](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/tokio-rs/tls/blob/master/tokio-native-tls/LICENSE)
+[![docs.rs](https://docs.rs/tokio-native-tls/badge.svg)](https://docs.rs/tokio-native-tls/)
 
-An implementation of TLS/SSL streams for Tokio built on top of the [`native-tls`
-crate]
+An implementation of TLS/SSL streams for Tokio built on top of the
+[`native-tls`](https://crates.io/crates/native-tls) crate.
 
 ## License
 


### PR DESCRIPTION
Fixes some links and adds the same badge for `tokio-native-tls`.