### PR TITLE
rustls: Remove redundant function get_mut()

### DIFF
--- a/tokio-rustls/src/client.rs
+++ b/tokio-rustls/src/client.rs
@@ -18,11 +18,6 @@ impl<IO> TlsStream<IO> {
     }
 
     #[inline]
-    pub fn get_mut(&mut self) -> (&mut IO, &mut ClientSession) {
-        (&mut self.io, &mut self.session)
-    }
-
-    #[inline]
     pub fn into_inner(self) -> (IO, ClientSession) {
         (self.io, self.session)
     }

--- a/tokio-rustls/src/lib.rs
+++ b/tokio-rustls/src/lib.rs
@@ -214,20 +214,6 @@ impl<T> TlsStream<T> {
             }
         }
     }
-
-    pub fn get_mut(&mut self) -> (&mut T, &mut dyn Session) {
-        use TlsStream::*;
-        match self {
-            Client(io) => {
-                let (io, session) = io.get_mut();
-                (io, &mut *session)
-            }
-            Server(io) => {
-                let (io, session) = io.get_mut();
-                (io, &mut *session)
-            }
-        }
-    }
 }
 
 impl<T> From<client::TlsStream<T>> for TlsStream<T> {

--- a/tokio-rustls/src/server.rs
+++ b/tokio-rustls/src/server.rs
@@ -18,11 +18,6 @@ impl<IO> TlsStream<IO> {
     }
 
     #[inline]
-    pub fn get_mut(&mut self) -> (&mut IO, &mut ServerSession) {
-        (&mut self.io, &mut self.session)
-    }
-
-    #[inline]
     pub fn into_inner(self) -> (IO, ServerSession) {
         (self.io, self.session)
     }


### PR DESCRIPTION
get_mut() is an unused function, and is different from the get_mut() prototype in IoSession, which is easy to cause confusion, so delete it.