### PR TITLE
Allow vendoring openssl

### DIFF
--- a/tokio-native-tls/Cargo.toml
+++ b/tokio-native-tls/Cargo.toml
@@ -21,6 +21,9 @@ for nonblocking I/O streams.
 """
 categories = ["asynchronous", "network-programming"]
 
+[features]
+vendored-openssl = ["native-tls/vendored"]
+
 [dependencies]
 native-tls = "0.2"
 tokio = "1.0"


### PR DESCRIPTION
We have certain environments where vendoring OpenSSL is the only possible solution to get somehow sane compilation for our users. native-tls has a parameter for this, and it only does something on Linux environments. Now, if our users run on AWS Lambda, which is Amazon Linux 2 and holds openssl 1.0. And the node version they have statically links against 1.1.1j, calling a rust napi module linking against openssl 1.0 from statically linked nodejs will cause tls errors due to the cipher params being different.

Would it be possible to expose this feature from `tokio-native-tls` so we could use this flag from crates such as `mysql_async` and `tokio-postgres`?