### PR TITLE
fix a handful of lints, one of which was breaking the build

### DIFF
--- a/tokio-native-tls/examples/echo.rs
+++ b/tokio-native-tls/examples/echo.rs
@@ -1,9 +1,7 @@
 #![warn(rust_2018_idioms)]
 
 // A tiny async TLS echo server with Tokio
-use native_tls;
 use native_tls::Identity;
-use tokio;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 

--- a/tokio-native-tls/tests/bad.rs
+++ b/tokio-native-tls/tests/bad.rs
@@ -1,7 +1,6 @@
 #![warn(rust_2018_idioms)]
 
 use cfg_if::cfg_if;
-use env_logger;
 use native_tls::TlsConnector;
 use std::io::{self, Error};
 use std::net::ToSocketAddrs;

--- a/tokio-native-tls/tests/google.rs
+++ b/tokio-native-tls/tests/google.rs
@@ -1,8 +1,6 @@
 #![warn(rust_2018_idioms)]
 
 use cfg_if::cfg_if;
-use env_logger;
-use native_tls;
 use native_tls::TlsConnector;
 use std::io;
 use std::net::ToSocketAddrs;

--- a/tokio-native-tls/tests/smoke.rs
+++ b/tokio-native-tls/tests/smoke.rs
@@ -123,7 +123,7 @@ async fn one_byte_at_a_time() {
             match socket.read_exact(&mut buf).await {
                 Ok(_) => data.extend_from_slice(&buf),
                 Err(ref err) if err.kind() == std::io::ErrorKind::UnexpectedEof => break,
-                Err(err) => panic!(err),
+                Err(err) => panic!("{}", err),
             }
         }
         data

--- a/tokio-rustls/src/common/test_stream.rs
+++ b/tokio-rustls/src/common/test_stream.rs
@@ -118,7 +118,7 @@ impl AsyncWrite for Eof {
 
 #[tokio::test]
 async fn stream_good() -> io::Result<()> {
-    const FILE: &'static [u8] = include_bytes!("../../README.md");
+    const FILE: &[u8] = include_bytes!("../../README.md");
 
     let (mut server, mut client) = make_pair();
     poll_fn(|cx| do_handshake(&mut client, &mut server, cx)).await?;

--- a/tokio-rustls/tests/test.rs
+++ b/tokio-rustls/tests/test.rs
@@ -75,7 +75,7 @@ fn start_server() -> &'static (SocketAddr, &'static str, &'static str) {
 }
 
 async fn start_client(addr: SocketAddr, domain: &str, config: Arc<ClientConfig>) -> io::Result<()> {
-    const FILE: &'static [u8] = include_bytes!("../README.md");
+    const FILE: &[u8] = include_bytes!("../README.md");
 
     let domain = webpki::DNSNameRef::try_from_ascii_str(domain).unwrap();
     let config = TlsConnector::from(config);
@@ -107,7 +107,7 @@ async fn pass() -> io::Result<()> {
     config.root_store.add_pem_file(&mut chain).unwrap();
     let config = Arc::new(config);
 
-    start_client(addr.clone(), domain, config.clone()).await?;
+    start_client(*addr, domain, config.clone()).await?;
 
     Ok(())
 }
@@ -122,7 +122,7 @@ async fn fail() -> io::Result<()> {
     let config = Arc::new(config);
 
     assert_ne!(domain, &"google.com");
-    let ret = start_client(addr.clone(), "google.com", config).await;
+    let ret = start_client(*addr, "google.com", config).await;
     assert!(ret.is_err());
 
     Ok(())


### PR DESCRIPTION
This branch fixes a number of lints. The most important one was the use
of a non-`format_args!` expression in a `panic!` macro, which generates
a compiler warning in recent Rust toolchains, which is breaking the CI
`cargo check` run on PR #64.

While I was here, I also fixed some miscellaneous Clippy lints, mostly
in tests. These include:

* Use of `clone()` on `SocketAddr`s (which implement `Copy`)
* Unnecessary single-path-segment imports (which probably used to be
  `extern crate`s in earlier Rust?)
* `'static` lifetimes in `const` type annotations (`const`s always have
  the `'static` lifetime)

None of these were breaking the build on CI, but I figured I'd address
them while I was fixing other lints.
