### PR TITLE
Implement AsRawFd for both tokio-rustls and tokio-native-tls TlsStream<S>

### DIFF
--- a/tokio-native-tls/src/lib.rs
+++ b/tokio-native-tls/src/lib.rs
@@ -38,7 +38,7 @@ use std::marker::Unpin;
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, RawFd};
 #[cfg(windows)]
-use std::os::windows::io::{AsRawHandle, RawHandle};
+use std::os::windows::io::{AsRawSocket, RawSocket};
 use std::pin::Pin;
 use std::ptr::null_mut;
 use std::task::{Context, Poll};
@@ -230,12 +230,12 @@ where
 }
 
 #[cfg(windows)]
-impl<S> AsRawHandle for TlsStream<S>
+impl<S> AsRawSocket for TlsStream<S>
 where
-    S: AsRawHandle,
+    S: AsRawSocket,
 {
-    fn as_raw_handle(&self) -> RawHandle {
-        self.get_ref().get_ref().get_ref().as_raw_handle()
+    fn as_raw_socket(&self) -> RawSocket {
+        self.get_ref().get_ref().get_ref().as_raw_socket()
     }
 }
 

--- a/tokio-native-tls/src/lib.rs
+++ b/tokio-native-tls/src/lib.rs
@@ -35,6 +35,8 @@ use std::fmt;
 use std::future::Future;
 use std::io::{self, Read, Write};
 use std::marker::Unpin;
+#[cfg(unix)]
+use std::os::unix::io::{AsRawFd, RawFd};
 use std::pin::Pin;
 use std::ptr::null_mut;
 use std::task::{Context, Poll};
@@ -167,18 +169,12 @@ impl<S> TlsStream<S> {
     }
 
     /// Returns a shared reference to the inner stream.
-    pub fn get_ref(&self) -> &native_tls::TlsStream<AllowStd<S>>
-    where
-        S: AsyncRead + AsyncWrite + Unpin,
-    {
+    pub fn get_ref(&self) -> &native_tls::TlsStream<AllowStd<S>> {
         &self.0
     }
 
     /// Returns a mutable reference to the inner stream.
-    pub fn get_mut(&mut self) -> &mut native_tls::TlsStream<AllowStd<S>>
-    where
-        S: AsyncRead + AsyncWrite + Unpin,
-    {
+    pub fn get_mut(&mut self) -> &mut native_tls::TlsStream<AllowStd<S>> {
         &mut self.0
     }
 }
@@ -218,6 +214,16 @@ where
 
     fn poll_shutdown(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<io::Result<()>> {
         self.with_context(ctx, |s| s.shutdown())
+    }
+}
+
+#[cfg(unix)]
+impl<S> AsRawFd for TlsStream<S>
+where
+    S: AsRawFd,
+{
+    fn as_raw_fd(&self) -> RawFd {
+        self.get_ref().get_ref().get_ref().as_raw_fd()
     }
 }
 

--- a/tokio-native-tls/src/lib.rs
+++ b/tokio-native-tls/src/lib.rs
@@ -37,6 +37,8 @@ use std::io::{self, Read, Write};
 use std::marker::Unpin;
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, RawFd};
+#[cfg(windows)]
+use std::os::windows::io::{AsRawHandle, RawHandle};
 use std::pin::Pin;
 use std::ptr::null_mut;
 use std::task::{Context, Poll};
@@ -224,6 +226,16 @@ where
 {
     fn as_raw_fd(&self) -> RawFd {
         self.get_ref().get_ref().get_ref().as_raw_fd()
+    }
+}
+
+#[cfg(windows)]
+impl<S> AsRawHandle for TlsStream<S>
+where
+    S: AsRawHandle,
+{
+    fn as_raw_handle(&self) -> RawHandle {
+        self.get_ref().get_ref().get_ref().as_raw_handle()
     }
 }
 

--- a/tokio-rustls/src/client.rs
+++ b/tokio-rustls/src/client.rs
@@ -1,5 +1,9 @@
 use super::*;
 use crate::common::IoSession;
+#[cfg(unix)]
+use std::os::unix::io::{AsRawFd, RawFd};
+#[cfg(windows)]
+use std::os::windows::io::{AsRawSocket, RawSocket};
 
 /// A wrapper around an underlying raw stream which implements the TLS or SSL
 /// protocol.
@@ -24,6 +28,26 @@ impl<IO> TlsStream<IO> {
     #[inline]
     pub fn into_inner(self) -> (IO, ClientConnection) {
         (self.io, self.session)
+    }
+}
+
+#[cfg(unix)]
+impl<S> AsRawFd for TlsStream<S>
+where
+    S: AsRawFd,
+{
+    fn as_raw_fd(&self) -> RawFd {
+        self.get_ref().0.as_raw_fd()
+    }
+}
+
+#[cfg(windows)]
+impl<S> AsRawSocket for TlsStream<S>
+where
+    S: AsRawSocket,
+{
+    fn as_raw_socket(&self) -> RawSocket {
+        self.get_ref().0.as_raw_socket()
     }
 }
 

--- a/tokio-rustls/src/lib.rs
+++ b/tokio-rustls/src/lib.rs
@@ -17,6 +17,10 @@ use common::{MidHandshake, Stream, TlsState};
 use rustls::{ClientConfig, ClientConnection, CommonState, ServerConfig, ServerConnection};
 use std::future::Future;
 use std::io;
+#[cfg(unix)]
+use std::os::unix::io::{AsRawFd, RawFd};
+#[cfg(windows)]
+use std::os::windows::io::{AsRawSocket, RawSocket};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -258,6 +262,26 @@ impl<T> From<client::TlsStream<T>> for TlsStream<T> {
 impl<T> From<server::TlsStream<T>> for TlsStream<T> {
     fn from(s: server::TlsStream<T>) -> Self {
         Self::Server(s)
+    }
+}
+
+#[cfg(unix)]
+impl<S> AsRawFd for TlsStream<S>
+where
+    S: AsRawFd,
+{
+    fn as_raw_fd(&self) -> RawFd {
+        self.get_ref().0.as_raw_fd()
+    }
+}
+
+#[cfg(windows)]
+impl<S> AsRawSocket for TlsStream<S>
+where
+    S: AsRawSocket,
+{
+    fn as_raw_socket(&self) -> RawSocket {
+        self.get_ref().0.as_raw_socket()
     }
 }
 

--- a/tokio-rustls/src/server.rs
+++ b/tokio-rustls/src/server.rs
@@ -1,6 +1,6 @@
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, RawFd};
-#[cfg(window)]
+#[cfg(windows)]
 use std::os::windows::io::{AsRawHandle, RawHandle};
 
 use super::*;

--- a/tokio-rustls/src/server.rs
+++ b/tokio-rustls/src/server.rs
@@ -1,5 +1,7 @@
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, RawFd};
+#[cfg(window)]
+use std::os::windows::io::{AsRawHandle, RawHandle};
 
 use super::*;
 use crate::common::IoSession;
@@ -134,5 +136,15 @@ where
 {
     fn as_raw_fd(&self) -> RawFd {
         self.get_ref().0.as_raw_fd()
+    }
+}
+
+#[cfg(windows)]
+impl<IO> AsRawHandle for TlsStream<IO>
+where
+    IO: AsRawHandle,
+{
+    fn as_raw_handle(&self) -> RawHandle {
+        self.get_ref().0.as_raw_handle()
     }
 }

--- a/tokio-rustls/src/server.rs
+++ b/tokio-rustls/src/server.rs
@@ -1,3 +1,6 @@
+#[cfg(unix)]
+use std::os::unix::io::{AsRawFd, RawFd};
+
 use super::*;
 use crate::common::IoSession;
 
@@ -121,5 +124,15 @@ where
         let mut stream =
             Stream::new(&mut this.io, &mut this.session).set_eof(!this.state.readable());
         stream.as_mut_pin().poll_shutdown(cx)
+    }
+}
+
+#[cfg(unix)]
+impl<IO> AsRawFd for TlsStream<IO>
+where
+    IO: AsRawFd,
+{
+    fn as_raw_fd(&self) -> RawFd {
+        self.get_ref().0.as_raw_fd()
     }
 }

--- a/tokio-rustls/src/server.rs
+++ b/tokio-rustls/src/server.rs
@@ -1,7 +1,7 @@
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, RawFd};
 #[cfg(windows)]
-use std::os::windows::io::{AsRawHandle, RawHandle};
+use std::os::windows::io::{AsRawSocket, RawSocket};
 
 use super::*;
 use crate::common::IoSession;
@@ -140,11 +140,11 @@ where
 }
 
 #[cfg(windows)]
-impl<IO> AsRawHandle for TlsStream<IO>
+impl<IO> AsRawSocket for TlsStream<IO>
 where
-    IO: AsRawHandle,
+    IO: AsRawSocket,
 {
-    fn as_raw_handle(&self) -> RawHandle {
-        self.get_ref().0.as_raw_handle()
+    fn as_raw_socket(&self) -> RawSocket {
+        self.get_ref().0.as_raw_socket()
     }
 }


### PR DESCRIPTION
We've been needing this to `getsockopt` on the underlying stream. I've been maintaining a fork like that for a long time now but never upstreamed it.

Edit: I've removed the `AsyncRead + AsyncWrite + Unpin` trait bounds on `S` for `tokio-native-tls`'s `TlsStream<S>`'s `get_ref(&self)` and `get_mut(&self)` functions. They didn't seem necessary and the compiler would've needed me to only be able to implement `AsRawFd` if `S` was also `AsyncRead + AsyncWrite + Unpin` which didn't make sense to me. I'm happy to bring them back if that's a problem.