### PR TITLE
Remove webpki

### DIFF
--- a/tokio-rustls/Cargo.toml
+++ b/tokio-rustls/Cargo.toml
@@ -15,7 +15,6 @@ rust-version = "1.56"
 [dependencies]
 tokio = "1.0"
 rustls = { version = "0.21.0", default-features = false }
-webpki = { package = "rustls-webpki", version = "0.100.0", features = ["alloc", "std"] }
 
 [features]
 default = ["logging", "tls12"]
@@ -30,3 +29,4 @@ futures-util = "0.3.1"
 lazy_static = "1"
 webpki-roots = "0.22"
 rustls-pemfile = "1"
+webpki = { package = "rustls-webpki", version = "0.100.0", features = ["alloc", "std"] }

--- a/tokio-rustls/examples/client/Cargo.toml
+++ b/tokio-rustls/examples/client/Cargo.toml
@@ -9,5 +9,6 @@ rust-version = "1.56"
 tokio = { version = "1.0", features = [ "full" ] }
 argh = "0.1"
 tokio-rustls = { path = "../.." }
+webpki = { package = "rustls-webpki", version = "0.100.0", features = ["alloc", "std"] }
 webpki-roots = "0.22"
 rustls-pemfile = "1.0"

--- a/tokio-rustls/examples/client/src/main.rs
+++ b/tokio-rustls/examples/client/src/main.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use tokio::io::{copy, split, stdin as tokio_stdin, stdout as tokio_stdout, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio_rustls::rustls::{self, OwnedTrustAnchor};
-use tokio_rustls::{webpki, TlsConnector};
+use tokio_rustls::TlsConnector;
 
 /// Tokio Rustls client example
 #[derive(FromArgs)]

--- a/tokio-rustls/src/lib.rs
+++ b/tokio-rustls/src/lib.rs
@@ -63,7 +63,6 @@ use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 pub use rustls;
-pub use webpki;
 
 /// A wrapper around a `rustls::ClientConfig`, providing an async `connect` method.
 #[derive(Clone)]


### PR DESCRIPTION
Removes webpki from the public API, matching the rustls 0.20 move to also remove it from its public API https://github.com/rustls/rustls/issues/736.
Unfortunately this PR is a breaking change as webpki was being re-exported by tokio-rustls.