### PR TITLE
fix: Fix EOF spin loop by removing intermediate buffer in LazyConfigAcceptor

### DIFF
--- a/tokio-rustls/src/common/mod.rs
+++ b/tokio-rustls/src/common/mod.rs
@@ -328,6 +328,8 @@ where
 
 /// An adaptor that implements a [`Read`] interface for [`AsyncRead`] types and an
 /// associated [`Context`].
+///
+/// Turns `Poll::Pending` into `WouldBlock`.
 pub struct Reader<'a, 'b, T> {
     pub io: &'a mut T,
     pub cx: &'a mut Context<'b>,

--- a/tokio-rustls/src/common/mod.rs
+++ b/tokio-rustls/src/common/mod.rs
@@ -89,7 +89,7 @@ where
     }
 
     pub fn read_io(&mut self, cx: &mut Context) -> Poll<io::Result<usize>> {
-        let mut reader = Reader { io: self.io, cx };
+        let mut reader = SyncReadAdapter { io: self.io, cx };
 
         let n = match self.session.read_tls(&mut reader) {
             Ok(n) => n,
@@ -326,16 +326,16 @@ where
     }
 }
 
-/// An adaptor that implements a [`Read`] interface for [`AsyncRead`] types and an
+/// An adapter that implements a [`Read`] interface for [`AsyncRead`] types and an
 /// associated [`Context`].
 ///
 /// Turns `Poll::Pending` into `WouldBlock`.
-pub struct Reader<'a, 'b, T> {
+pub struct SyncReadAdapter<'a, 'b, T> {
     pub io: &'a mut T,
     pub cx: &'a mut Context<'b>,
 }
 
-impl<'a, 'b, T: AsyncRead + Unpin> Read for Reader<'a, 'b, T> {
+impl<'a, 'b, T: AsyncRead + Unpin> Read for SyncReadAdapter<'a, 'b, T> {
     #[inline]
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let mut buf = ReadBuf::new(buf);

--- a/tokio-rustls/src/common/mod.rs
+++ b/tokio-rustls/src/common/mod.rs
@@ -128,7 +128,7 @@ where
                 &mut self,
                 f: impl FnOnce(Pin<&mut T>, &mut Context<'_>) -> Poll<io::Result<U>>,
             ) -> io::Result<U> {
-                match f(Pin::new(&mut self.io), self.cx) {
+                match f(Pin::new(self.io), self.cx) {
                     Poll::Ready(result) => result,
                     Poll::Pending => Err(io::ErrorKind::WouldBlock.into()),
                 }

--- a/tokio-rustls/src/lib.rs
+++ b/tokio-rustls/src/lib.rs
@@ -225,7 +225,7 @@ where
                 }
             };
 
-            let mut reader = common::Reader { io, cx };
+            let mut reader = common::SyncReadAdapter { io, cx };
             match this.acceptor.read_tls(&mut reader) {
                 Ok(0) => return Err(io::ErrorKind::UnexpectedEof.into()).into(),
                 Ok(_) => {}


### PR DESCRIPTION
This PR removes the intermediate buffer (thereby also fixes #85, I believe) in `LazyConfigAcceptor`, by reusing the `AsyncRead`-`Read` bridge `Reader` struct in the common module. I believe this lets rustls read right from the `IO` passed in. 

Looking forward to your review!