### PR TITLE
add dangle client for tokio-rustls example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,6 @@ members = [
     "tokio-native-tls",
     "tokio-rustls",
     "tokio-rustls/examples/client",
+    "tokio-rustls/examples/dangleclient",
     "tokio-rustls/examples/server"
 ]

--- a/tokio-rustls/examples/dangleclient/Cargo.toml
+++ b/tokio-rustls/examples/dangleclient/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "dangleclient"
+version = "0.1.0"
+authors = ["yumingming <yumm_007@163.com>"]
+edition = "2018"
+
+[dependencies]
+tokio = { version = "1.0", features = [ "full" ] }
+rustls = { version = "0.20", features = ["dangerous_configuration"] }
+argh = "0.1"
+tokio-rustls = { path = "../.." }
+rustls-pemfile = "0.2"

--- a/tokio-rustls/examples/dangleclient/src/main.rs
+++ b/tokio-rustls/examples/dangleclient/src/main.rs
@@ -1,0 +1,105 @@
+use argh::FromArgs;
+use std::convert::TryFrom;
+use std::io;
+use std::net::ToSocketAddrs;
+use std::sync::Arc;
+use std::time::SystemTime;
+use tokio::io::{copy, split, stdin as tokio_stdin, stdout as tokio_stdout, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio_rustls::rustls::client::{
+    HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier,
+};
+use tokio_rustls::rustls::internal::msgs::handshake::DigitallySignedStruct;
+use tokio_rustls::rustls::{self, Certificate, Error, ServerName};
+use tokio_rustls::TlsConnector;
+
+/// Tokio Rustls client example
+#[derive(FromArgs)]
+struct Options {
+    /// ip
+    #[argh(positional)]
+    ip: String,
+
+    /// port
+    #[argh(option, short = 'p', default = "443")]
+    port: u16,
+
+}
+
+struct NoCertificateVerification {}
+impl ServerCertVerifier for NoCertificateVerification {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &Certificate,
+        _intermediates: &[Certificate],
+        _server_name: &ServerName,
+        _scts: &mut dyn Iterator<Item = &[u8]>,
+        _ocsp_response: &[u8],
+        _now: SystemTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &Certificate,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &Certificate,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+}
+
+#[tokio::main]
+async fn main() -> io::Result<()> {
+    let options: Options = argh::from_env();
+
+    let addr = (options.ip.as_str(), options.port)
+        .to_socket_addrs()?
+        .next()
+        .ok_or_else(|| io::Error::from(io::ErrorKind::NotFound))?;
+
+    let content = format!("GET / HTTP/1.0\r\nHost: {}\r\n\r\n", options.ip);
+
+    let mut config = rustls::ClientConfig::builder()
+        .with_safe_defaults()
+        .with_custom_certificate_verifier(Arc::new(NoCertificateVerification {}))
+        .with_no_client_auth();
+
+    config.enable_sni = false;
+
+    let connector = TlsConnector::from(Arc::new(config));
+
+    let stream = TcpStream::connect(&addr).await?;
+
+    let (mut stdin, mut stdout) = (tokio_stdin(), tokio_stdout());
+
+    let domain = rustls::ServerName::try_from("localhost")
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dnsname"))?;
+
+    let mut stream = connector.connect(domain, stream).await?;
+    stream.write_all(content.as_bytes()).await?;
+
+    let (mut reader, mut writer) = split(stream);
+
+    tokio::select! {
+        ret = copy(&mut reader, &mut stdout) => {
+            ret?;
+        },
+        ret = copy(&mut stdin, &mut writer) => {
+            ret?;
+            writer.shutdown().await?
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
# start server
cargo run -- 0.0.0.0:8045 --cert ../key/cert.pem --key ../key/server.key.pem

# start client with ip
cargo run -- -p 8045 127.0.0.1