### PR TITLE
Rustls buffered handshake eof failed

### DIFF
--- a/tokio-rustls/Cargo.toml
+++ b/tokio-rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-rustls"
-version = "0.23.2"
+version = "0.23.3"
 authors = ["quininer kel <quininer@live.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/tokio-rs/tls"

--- a/tokio-rustls/src/common/handshake.rs
+++ b/tokio-rustls/src/common/handshake.rs
@@ -62,9 +62,7 @@ where
                 try_poll!(tls_stream.handshake(cx));
             }
 
-            while tls_stream.session.wants_write() {
-                try_poll!(tls_stream.write_io(cx));
-            }
+            try_poll!(Pin::new(&mut tls_stream).poll_flush(cx));
         }
 
         Poll::Ready(Ok(stream))

--- a/tokio-rustls/src/common/mod.rs
+++ b/tokio-rustls/src/common/mod.rs
@@ -166,10 +166,14 @@ where
         loop {
             let mut write_would_block = false;
             let mut read_would_block = false;
+            let mut need_flush = false;
 
             while self.session.wants_write() {
                 match self.write_io(cx) {
-                    Poll::Ready(Ok(n)) => wrlen += n,
+                    Poll::Ready(Ok(n)) => {
+                        wrlen += n;
+                        need_flush = true;
+                    },
                     Poll::Pending => {
                         write_would_block = true;
                         break;
@@ -178,7 +182,7 @@ where
                 }
             }
 
-            if wrlen != 0 {
+            if need_flush {
                 match Pin::new(&mut self.io).poll_flush(cx) {
                     Poll::Ready(Ok(())) => (),
                     Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),

--- a/tokio-rustls/src/common/mod.rs
+++ b/tokio-rustls/src/common/mod.rs
@@ -173,7 +173,7 @@ where
                     Poll::Ready(Ok(n)) => {
                         wrlen += n;
                         need_flush = true;
-                    },
+                    }
                     Poll::Pending => {
                         write_would_block = true;
                         break;
@@ -186,7 +186,7 @@ where
                 match Pin::new(&mut self.io).poll_flush(cx) {
                     Poll::Ready(Ok(())) => (),
                     Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
-                    Poll::Pending => write_would_block = true
+                    Poll::Pending => write_would_block = true,
                 }
             }
 

--- a/tokio-rustls/src/common/mod.rs
+++ b/tokio-rustls/src/common/mod.rs
@@ -178,6 +178,14 @@ where
                 }
             }
 
+            if wrlen != 0 {
+                match Pin::new(&mut self.io).poll_flush(cx) {
+                    Poll::Ready(Ok(())) => (),
+                    Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
+                    Poll::Pending => write_would_block = true
+                }
+            }
+
             while !self.eof && self.session.wants_read() {
                 match self.read_io(cx) {
                     Poll::Ready(Ok(0)) => self.eof = true,

--- a/tokio-rustls/src/common/test_stream.rs
+++ b/tokio-rustls/src/common/test_stream.rs
@@ -5,7 +5,7 @@ use rustls::{ClientConnection, Connection, ServerConnection};
 use std::io::{self, Cursor, Read, Write};
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf, BufWriter};
 
 struct Good<'a>(&'a mut Connection);
 
@@ -273,7 +273,7 @@ fn do_handshake(
     server: &mut Connection,
     cx: &mut Context<'_>,
 ) -> Poll<io::Result<()>> {
-    let mut good = Good(server);
+    let mut good = BufWriter::new(Good(server));
     let mut stream = Stream::new(&mut good, client);
 
     while stream.session.is_handshaking() {


### PR DESCRIPTION
This fixes an issue (#96) where flush could be lost during handshake.

This does not check read pending , because rustls read always returns 0 before there is data to write, which would cause test to fail. And I believe it should always be beneficial to flush during the handshake phase.