### PR TITLE
The scope of the unsafe block can be appropriately reduced

### DIFF
--- a/tokio-native-tls/src/lib.rs
+++ b/tokio-native-tls/src/lib.rs
@@ -120,14 +120,14 @@ where
     where
         F: FnOnce(&mut Context<'_>, Pin<&mut S>) -> Poll<io::Result<R>>,
     {
-        unsafe {
+        
             assert!(!self.context.is_null());
-            let waker = &mut *(self.context as *mut _);
+            let waker = unsafe { &mut *(self.context as *mut _) };
             match f(waker, Pin::new(&mut self.inner)) {
                 Poll::Ready(r) => r,
                 Poll::Pending => Err(io::Error::from(io::ErrorKind::WouldBlock)),
             }
-        }
+        
     }
 }
 


### PR DESCRIPTION
In this function you use the unsafe keyword for almost the entrie function body. 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust.

Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html