### PR TITLE
use features to make tokio-rustls compatible with `futures` interface

### DIFF
--- a/tokio-rustls/Cargo.toml
+++ b/tokio-rustls/Cargo.toml
@@ -15,9 +15,10 @@ edition = "2018"
 tokio = "1.0"
 rustls = { version = "0.20", default-features = false }
 webpki = "0.22"
-
+futures = { version = "0.3", optional = true }
 [features]
 default = ["logging", "tls12"]
+use-futures = ["futures"]
 dangerous_configuration = ["rustls/dangerous_configuration"]
 early-data = []
 logging = ["rustls/logging"]
@@ -25,6 +26,7 @@ tls12 = ["rustls/tls12"]
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full"] }
+tokio-async-std = "1"
 futures-util = "0.3.1"
 lazy_static = "1"
 webpki-roots = "0.22"

--- a/tokio-rustls/src/common/handshake.rs
+++ b/tokio-rustls/src/common/handshake.rs
@@ -1,10 +1,13 @@
 use crate::common::{Stream, TlsState};
+#[cfg(feature = "use-futures")]
+use futures::io::{AsyncRead, AsyncWrite};
 use rustls::{ConnectionCommon, SideData};
 use std::future::Future;
 use std::ops::{Deref, DerefMut};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::{io, mem};
+#[cfg(not(feature = "use-futures"))]
 use tokio::io::{AsyncRead, AsyncWrite};
 
 pub(crate) trait IoSession {

--- a/tokio-rustls/src/server.rs
+++ b/tokio-rustls/src/server.rs
@@ -59,23 +59,34 @@ where
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-        buf: &mut ReadBuf<'_>,
-    ) -> Poll<io::Result<()>> {
+        #[cfg(not(feature = "use-futures"))] buf: &mut ReadBuf<'_>,
+        #[cfg(feature = "use-futures")] buf: &mut [u8],
+    ) -> Poll<io::Result<PollReadResult>> {
         let this = self.get_mut();
         let mut stream =
             Stream::new(&mut this.io, &mut this.session).set_eof(!this.state.readable());
 
         match &this.state {
             TlsState::Stream | TlsState::WriteShutdown => {
+                #[cfg(not(feature = "use-futures"))]
                 let prev = buf.remaining();
 
                 match stream.as_mut_pin().poll_read(cx, buf) {
+                    #[cfg(not(feature = "use-futures"))]
                     Poll::Ready(Ok(())) => {
                         if prev == buf.remaining() || stream.eof {
                             this.state.shutdown_read();
                         }
 
                         Poll::Ready(Ok(()))
+                    }
+                    #[cfg(feature = "use-futures")]
+                    Poll::Ready(Ok(n)) => {
+                        if n == 0 || stream.eof {
+                            this.state.shutdown_read();
+                        }
+
+                        Poll::Ready(Ok(n))
                     }
                     Poll::Ready(Err(err)) if err.kind() == io::ErrorKind::UnexpectedEof => {
                         this.state.shutdown_read();
@@ -84,7 +95,10 @@ where
                     output => output,
                 }
             }
+            #[cfg(not(feature = "use-futures"))]
             TlsState::ReadShutdown | TlsState::FullyShutdown => Poll::Ready(Ok(())),
+            #[cfg(feature = "use-futures")]
+            TlsState::ReadShutdown | TlsState::FullyShutdown => Poll::Ready(Ok(0)),
             #[cfg(feature = "early-data")]
             s => unreachable!("server TLS can not hit this state: {:?}", s),
         }
@@ -115,6 +129,20 @@ where
         stream.as_mut_pin().poll_flush(cx)
     }
 
+    #[cfg(feature = "use-futures")]
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        if self.state.writeable() {
+            self.session.send_close_notify();
+            self.state.shutdown_write();
+        }
+
+        let this = self.get_mut();
+        let mut stream =
+            Stream::new(&mut this.io, &mut this.session).set_eof(!this.state.readable());
+        stream.as_mut_pin().poll_close(cx)
+    }
+
+    #[cfg(not(feature = "use-futures"))]
     fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         if self.state.writeable() {
             self.session.send_close_notify();

--- a/tokio-rustls/tests/badssl.rs
+++ b/tokio-rustls/tests/badssl.rs
@@ -2,8 +2,14 @@ use std::convert::TryFrom;
 use std::io;
 use std::net::ToSocketAddrs;
 use std::sync::Arc;
+#[cfg(not(feature = "use-futures"))]
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
+#[cfg(not(feature = "use-futures"))]
 use tokio::net::TcpStream;
+#[cfg(feature = "use-futures")]
+use async_std::net::TcpStream;
+#[cfg(feature = "use-futures")]
+use futures::io::{AsyncReadExt, AsyncWriteExt};
 use tokio_rustls::{
     client::TlsStream,
     rustls::{self, ClientConfig, OwnedTrustAnchor},


### PR DESCRIPTION
#115 enable `futures` users to contribute and use tokio-tls crate.