### PR TITLE
tokio-rustls: initialize Acceptor with default() in tests

### DIFF
--- a/tokio-rustls/Cargo.toml
+++ b/tokio-rustls/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dependencies]
 tokio = "1.0"
-rustls = { version = "0.20", default-features = false }
+rustls = { version = "0.20.7", default-features = false }
 webpki = "0.22"
 
 [features]

--- a/tokio-rustls/tests/test.rs
+++ b/tokio-rustls/tests/test.rs
@@ -176,7 +176,7 @@ async fn test_lazy_config_acceptor() -> io::Result<()> {
         client.read_to_end(&mut buf).await.unwrap();
     });
 
-    let acceptor = LazyConfigAcceptor::new(rustls::server::Acceptor::new().unwrap(), sstream);
+    let acceptor = LazyConfigAcceptor::new(rustls::server::Acceptor::default(), sstream);
     let start = acceptor.await.unwrap();
     let ch = start.client_hello();
 
@@ -201,7 +201,7 @@ async fn test_lazy_config_acceptor() -> io::Result<()> {
 #[tokio::test]
 async fn lazy_config_acceptor_eof() {
     let buf = Cursor::new(Vec::new());
-    let acceptor = LazyConfigAcceptor::new(rustls::server::Acceptor::new().unwrap(), buf);
+    let acceptor = LazyConfigAcceptor::new(rustls::server::Acceptor::default(), buf);
 
     let accept_result = match time::timeout(Duration::from_secs(3), acceptor).await {
         Ok(res) => res,


### PR DESCRIPTION
CI is failing because rustls 0.20.7 deprecated `Acceptor::new()` in favor of the infallible `Acceptor::default()` constructor (https://github.com/rustls/rustls/pull/1046). The failure is caused because we're using `Acceptor::new()` in tests (not in the library) and CI denies warnings. This PR adopts `default()` and forces the dependency to 0.20.7, which would also force the MSRV up for the library. Alternatively, we could locally allow deprecations in the tests?