### PR TITLE
Clippy 1.67

### DIFF
--- a/tokio-rustls/Cargo.toml
+++ b/tokio-rustls/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 description = "Asynchronous TLS/SSL streams for Tokio using Rustls."
 categories = ["asynchronous", "cryptography", "network-programming"]
 edition = "2018"
+rust-version = "1.56"
 
 [dependencies]
 tokio = "1.0"

--- a/tokio-rustls/examples/client/Cargo.toml
+++ b/tokio-rustls/examples/client/Cargo.toml
@@ -3,6 +3,7 @@ name = "client"
 version = "0.1.0"
 authors = ["quininer <quininer@live.com>"]
 edition = "2018"
+rust-version = "1.56"
 
 [dependencies]
 tokio = { version = "1.0", features = [ "full" ] }

--- a/tokio-rustls/examples/server/Cargo.toml
+++ b/tokio-rustls/examples/server/Cargo.toml
@@ -3,6 +3,7 @@ name = "server"
 version = "0.1.0"
 authors = ["quininer <quininer@live.com>"]
 edition = "2018"
+rust-version = "1.56"
 
 [dependencies]
 tokio = { version = "1.0", features = [ "full" ] }

--- a/tokio-rustls/tests/test.rs
+++ b/tokio-rustls/tests/test.rs
@@ -79,7 +79,7 @@ lazy_static! {
 }
 
 fn start_server() -> &'static (SocketAddr, &'static str, &'static [u8]) {
-    &*TEST_SERVER
+    &TEST_SERVER
 }
 
 async fn start_client(addr: SocketAddr, domain: &str, config: Arc<ClientConfig>) -> io::Result<()> {


### PR DESCRIPTION
Clippy in 1.67 lints against `uninlined_format_args`, but disregards the edition when doing so (so it even warns in 2018 -- see https://github.com/rust-lang/rust-clippy/issues/10234). Since these are just the examples, bumping them to 2021 probably doesn't hurt, anyway.