### PR TITLE
Handle EOF like rustls::Stream

### DIFF
--- a/tokio-rustls/src/common/mod.rs
+++ b/tokio-rustls/src/common/mod.rs
@@ -237,6 +237,11 @@ where
         while !self.eof && self.session.wants_read() {
             match self.read_io(cx) {
                 Poll::Ready(Ok(0)) => {
+                    if let Ok(io_state) = self.session.process_new_packets() {
+                        if io_state.plaintext_bytes_to_read() == 0 {
+                            return Poll::Ready(Ok(()));
+                        }
+                    }
                     break;
                 }
                 Poll::Ready(Ok(_)) => (),

--- a/tokio-rustls/src/common/test_stream.rs
+++ b/tokio-rustls/src/common/test_stream.rs
@@ -265,15 +265,12 @@ async fn stream_eof() -> io::Result<()> {
     let mut server = Connection::from(server);
     poll_fn(|cx| do_handshake(&mut client, &mut server, cx)).await?;
 
-    let mut bad = Expected(Cursor::new(Vec::new()));
-    let mut stream = Stream::new(&mut bad, &mut client);
+    let mut empty = Expected(Cursor::new(Vec::new()));
+    let mut stream = Stream::new(&mut empty, &mut client);
 
     let mut buf = Vec::new();
     let result = stream.read_to_end(&mut buf).await;
-    assert_eq!(
-        result.err().map(|e| e.kind()),
-        Some(io::ErrorKind::UnexpectedEof)
-    );
+    assert_eq!(result.ok(), Some(0));
 
     Ok(()) as io::Result<()>
 }


### PR DESCRIPTION
This aims to fix twilight-rs/twilight#1428, which is two layers of abstraction removed from tokio-rustls (this fix might therefore not be optimal). That bug occurs on closing a TLS encrypted websocket connetion with Discord's gateway. The following blocking RusTLS + tungstenite MRE shows no error:
```rust
use tracing_subscriber::filter::LevelFilter;
use tungstenite::{connect, Error};

fn main() {
    tracing_subscriber::fmt()
        .with_max_level(LevelFilter::TRACE)
        .init();

    let (mut socket, _) = connect("wss://gateway.discord.gg").expect("Can't connect");

    let hello = socket.read_message().unwrap();
    println!("{hello}");
    socket.close(None).unwrap();
    loop {
        match socket.read_message() {
            Ok(msg) => println!("{msg}"),
            Err(Error::ConnectionClosed) => break,
            Err(e) => panic!("{e}"),
        };
    }
}
```

Whereas the same exact code with tokio-tungstenite does error:

```rust
use tokio_stream::StreamExt;
use tokio_tungstenite::connect_async;
use tracing_subscriber::filter::LevelFilter;

#[tokio::main(flavor = "current_thread")]
async fn main() {
    tracing_subscriber::fmt()
        .with_max_level(LevelFilter::TRACE)
        .init();

    let (mut socket, _) = connect_async("wss://gateway.discord.gg")
        .await
        .expect("Can't connect");

    let hello = socket.next().await.unwrap().unwrap();
    println!("{hello}");
    socket.close(None).await.unwrap();
    loop {
        match socket.next().await {
            Some(Ok(msg)) => println!("{msg}"),
            Some(Err(e)) => panic!("{e}"),
            None => break,
        };
    }
}
```

In the first example, tungstenite uses the `rustls::Stream` abstraction to read from the websocket, and in the second example tokio-tungstenite uses `tokio_rustls::client::TlsStream` (which exposes a `Read` compatible interface to tungstenite). This leads me to believe the bug is in `tokio_rustls`.

`rustls::Stream`'s `Read` implemention is very similar to `tokio_rustls::client::TlsStream`'s `AsyncRead` (the logic I'm interested in for `tokio_tungstenite` is in the private `tokio_rustls::common::Stream` type), both calling `read_tls` while `wants_read` returns `true` and then calling `Reader::read` afterwards, but differs in two ways:

1. It calls `rustls::ConnectionCommon::complete_io()`, potentially writing data in addition to reading data
2. It returns early (before `Reader::read`) if `read_tls` returns `Ok(0)` *and* `process_new_packets` returns `Ok` with `IoState`'s `plaintext_bytes_to_read` returning `0`.

This PR then adds the logic from 2. to `tokio_rustls::common::Stream` which fixes the issue I'm running into.