### PR TITLE
chore: prepare tokio-native-tls 0.3.1

### DIFF
--- a/tokio-native-tls/Cargo.toml
+++ b/tokio-native-tls/Cargo.toml
@@ -8,7 +8,7 @@ name = "tokio-native-tls"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.3.0"
+version = "0.3.1"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"


### PR DESCRIPTION
# 0.3.1 (February 4th, 2023)

### Additions
- Add Vendored Feature ([#125])
- Implement AsRawFd for both tokio-rustls and tokio-native-tls TlsStream\<S\> ([#74])

### Internal
- Fix warning about renamed lint ([#93])
- fix a handful of lints, one of which was breaking the build ([#65])

[#65]: https://github.com/tokio-rs/tls/pull/65
[#74]: https://github.com/tokio-rs/tls/pull/74
[#93]: https://github.com/tokio-rs/tls/pull/93
[#125]: https://github.com/tokio-rs/tls/pull/125