### PR TITLE
Replace unmaintained GitHub Actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,11 +20,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Check
         run: cargo check --all --all-features --all-targets
@@ -40,13 +36,16 @@ jobs:
       RUSTFLAGS: "-D warnings"
 
     steps:
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: ${{ matrix.rust }}
-        profile: minimal
-    - uses: actions/checkout@v3
-    - name: Test
-      run: cargo test --all
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+
+      - name: Test
+        run: cargo test --all
 
   lints:
     name: Lints
@@ -56,21 +55,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: rustfmt, clippy
 
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all --check
 
       - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-features -- -D warnings
+        if: always()
+        run: cargo clippy --all-features -- -D warnings


### PR DESCRIPTION
The toolchain is now installed with `dtolnay/rust-toolchain` and `actions-rs/cargo` is replaced with plain commands.