### PR TITLE
Fix early-data test

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,7 +45,9 @@ jobs:
           toolchain: ${{ matrix.rust }}
 
       - name: Test
-        run: cargo test --all
+        run: |
+          cargo test --all
+          cargo test -p tokio-rustls --features early-data
 
   lints:
     name: Lints

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Test
         run: |
           cargo test --all
-          cargo test -p tokio-rustls --features early-data
+          cargo test -p tokio-rustls --features early-data --test early-data
 
   lints:
     name: Lints

--- a/tokio-rustls/tests/early-data.rs
+++ b/tokio-rustls/tests/early-data.rs
@@ -46,7 +46,7 @@ async fn send(
 ) -> io::Result<TlsStream<TcpStream>> {
     let connector = TlsConnector::from(config).early_data(true);
     let stream = TcpStream::connect(&addr).await?;
-    let domain = rustls::ServerName::try_from("testserver.com").unwrap();
+    let domain = rustls::ServerName::try_from("foobar.com").unwrap();
 
     let stream = connector.connect(domain, stream).await?;
     let (mut rd, mut wd) = split(stream);

--- a/tokio-rustls/tests/early-data.rs
+++ b/tokio-rustls/tests/early-data.rs
@@ -34,6 +34,7 @@ impl<T: AsyncRead + Unpin> Future for Read1<T> {
         if buf.filled().is_empty() {
             Poll::Ready(Ok(()))
         } else {
+            cx.waker().wake_by_ref();
             Poll::Pending
         }
     }


### PR DESCRIPTION
The domain name this test uses was not updated when the test certificate was replaced previously. FWIW, this test isn't covered by CI, since it's behind an off-by-default feature flag.