### PR TITLE
Bump security-framework version

### DIFF
--- a/tokio-native-tls/Cargo.toml
+++ b/tokio-native-tls/Cargo.toml
@@ -43,7 +43,7 @@ lazy_static = "1.4.0"
 openssl = "0.10"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dev-dependencies]
-security-framework = "0.2"
+security-framework = "2.8"
 
 [target.'cfg(windows)'.dev-dependencies]
 schannel = "0.1"


### PR DESCRIPTION
The 0.2 version was not only old but was also yanked. This commit updates the security-framework, also fixing builds on macos failing on dev-dependencies.

Signed-off-by: Tomasz Pietrek <melgaer@gmail.com>