### PR TITLE
tokio-rustls: Remove some feature

### DIFF
--- a/tokio-rustls/Cargo.toml
+++ b/tokio-rustls/Cargo.toml
@@ -17,10 +17,8 @@ tokio = "1.0"
 rustls = { version = "0.21.0", default-features = false }
 
 [features]
-default = ["logging", "tls12"]
-dangerous_configuration = ["rustls/dangerous_configuration"]
+default = ["tls12"]
 early-data = []
-logging = ["rustls/logging"]
 tls12 = ["rustls/tls12"]
 
 [dev-dependencies]

--- a/tokio-rustls/Cargo.toml
+++ b/tokio-rustls/Cargo.toml
@@ -16,6 +16,8 @@ rust-version = "1.56"
 tokio = "1.0"
 rustls = { version = "0.21.0", default-features = false }
 
+# This list is not a complete listing of all features of rustls.
+# If you want to enable a feature, please import rustls to enable it yourself.
 [features]
 default = ["tls12"]
 early-data = []


### PR DESCRIPTION
This MR removes some features that are not commonly used, so that anyone who wants to enable a feature can specify it by importing rustls crate directly.