### PR TITLE
tokio-rustls: Fix "Basic Structure of a Client" code in README

### DIFF
--- a/tokio-rustls/README.md
+++ b/tokio-rustls/README.md
@@ -11,18 +11,30 @@ Asynchronous TLS/SSL streams for [Tokio](https://tokio.rs/) using
 ### Basic Structure of a Client
 
 ```rust
-use webpki::DNSNameRef;
-use tokio_rustls::{ TlsConnector, rustls::ClientConfig };
+use std::sync::Arc;
+use tokio::net::TcpStream;
+use tokio_rustls::rustls::{ClientConfig, OwnedTrustAnchor, RootCertStore, ServerName};
+use tokio_rustls::TlsConnector;
 
 // ...
 
-let mut config = ClientConfig::new();
-config.root_store.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
-let config = TlsConnector::from(Arc::new(config));
-let dnsname = DNSNameRef::try_from_ascii_str("www.rust-lang.org").unwrap();
+let mut root_cert_store = RootCertStore::empty();
+root_cert_store.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
+    OwnedTrustAnchor::from_subject_spki_name_constraints(
+        ta.subject,
+        ta.spki,
+        ta.name_constraints,
+    )
+}));
+let config = ClientConfig::builder()
+    .with_safe_defaults()
+    .with_root_certificates(root_cert_store)
+    .with_no_client_auth();
+let connector = TlsConnector::from(Arc::new(config));
+let dnsname = ServerName::try_from("www.rust-lang.org").unwrap();
 
 let stream = TcpStream::connect(&addr).await?;
-let mut stream = config.connect(dnsname, stream).await?;
+let mut stream = connector.connect(dnsname, stream).await?;
 
 // ...
 ```


### PR DESCRIPTION
The code shown in tokio-rustls's README under "Basic Structure of a Client" does not work with the current version of the library.  Specifically, using tokio-rustls 0.24.0 and webpki 0.22.0, the following code:

```rust
use std::sync::Arc;
use tokio::net::{TcpStream, ToSocketAddrs};
use tokio_rustls::{rustls::ClientConfig, TlsConnector};
use webpki::DNSNameRef;

pub async fn tls_connect<A: ToSocketAddrs>(
    addr: A,
) -> std::io::Result<tokio_rustls::client::TlsStream<TcpStream>> {
    let mut config = ClientConfig::new();
    config
        .root_store
        .add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
    let config = TlsConnector::from(Arc::new(config));
    let dnsname = DNSNameRef::try_from_ascii_str("www.rust-lang.org").unwrap();
    let stream = TcpStream::connect(&addr).await?;
    config.connect(dnsname, stream).await
}
```

fails to build with the following errors (and warnings):

<details>

```
warning: use of deprecated type alias `webpki::DNSNameRef`: use DnsNameRef
 --> src/lib.rs:4:13
  |
4 | use webpki::DNSNameRef;
  |             ^^^^^^^^^^
  |
  = note: `#[warn(deprecated)]` on by default

warning: use of deprecated type alias `webpki::DNSNameRef`: use DnsNameRef
  --> src/lib.rs:14:19
   |
14 |     let dnsname = DNSNameRef::try_from_ascii_str("www.rust-lang.org").un...
   |                   ^^^^^^^^^^

error[E0599]: no function or associated item named `new` found for struct `ClientConfig` in the current scope
 --> src/lib.rs:9:36
  |
9 |     let mut config = ClientConfig::new();
  |                                    ^^^ function or associated item not found in `ClientConfig`

error[E0308]: mismatched types
   --> src/lib.rs:16:20
    |
16  |     config.connect(dnsname, stream).await
    |            ------- ^^^^^^^ expected enum `ServerName`, found struct `DnsNameRef`
    |            |
    |            arguments to this method are incorrect
    |
note: associated function defined here
   --> /Users/jwodder/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-rustls-0.24.0/src/lib.rs:109:12
    |
109 |     pub fn connect<IO>(&self, domain: rustls::ServerName, stream: IO) -...
    |            ^^^^^^^
```

</details>

This PR updates the README to something that will compile, based on the client example program.

Closes #100.