### PR TITLE
add server::AsyncAcceptor with take_io function

### DIFF
--- a/tokio-rustls/src/server.rs
+++ b/tokio-rustls/src/server.rs
@@ -6,6 +6,10 @@ use std::os::windows::io::{AsRawSocket, RawSocket};
 use super::*;
 use crate::common::IoSession;
 
+pub(crate) mod async_acceptor;
+
+pub use async_acceptor::AsyncAcceptor;
+
 /// A wrapper around an underlying raw stream which implements the TLS or SSL
 /// protocol.
 #[derive(Debug)]

--- a/tokio-rustls/src/server/async_acceptor.rs
+++ b/tokio-rustls/src/server/async_acceptor.rs
@@ -1,0 +1,98 @@
+use std::{
+    future::poll_fn,
+    task::{Context, Poll},
+};
+
+use crate::{common, StartHandshake};
+use tokio::io::{self, AsyncRead};
+
+/// Handle on a server-side connection before configuration is available.
+/// For more details, refer to [`rustls::server::Acceptor`].
+///
+/// # Example
+///
+/// ```no_run
+/// use tokio::io::AsyncWriteExt;
+/// let listener = tokio::net::TcpListener::bind("127.0.0.1:4443").await.unwrap();
+/// let (stream, _) = listener.accept().await.unwrap();
+/// let mut acceptor = tokio_rustls::AsyncAcceptor::new(stream);
+/// match acceptor.accept().await {
+///     Ok(start) => {
+///         let config = choose_server_config(start.client_hello()).await.unwrap();
+///         let stream = start.into_stream(config).await.unwrap();
+///         // Proceed with handling the ServerConnection...
+///     }
+///     Err(err) => {
+///         if let Some(mut stream) = acceptor.take_io() {
+///             stream
+///                 .write_all(
+///                     format!("HTTP/1.1 400 Invalid Input\r\n\r\n\r\n{:?}\n", err)
+///                         .as_bytes()
+///                 )
+///                 .await
+///                 .unwrap();
+///         }
+///     }
+/// }
+/// ```
+pub struct AsyncAcceptor<IO> {
+    acceptor: rustls::server::Acceptor,
+    io: Option<IO>,
+}
+
+impl<IO> AsyncAcceptor<IO>
+where
+    IO: AsyncRead + Unpin,
+{
+    /// Return an empty Acceptor, ready to receive bytes from a new client connection (io).
+    #[inline]
+    pub fn new(io: IO) -> Self {
+        Self {
+            acceptor: rustls::server::Acceptor::default(),
+            io: Some(io),
+        }
+    }
+
+    /// Wait for the `ClientHello` message from client. Do not call this function more than once.
+    ///
+    /// Returns `Ok(accepted)` if the connection has been accepted.
+    ///
+    /// Returns `Err(err)` if an error occurred. Use [`take_io`] to retrieve the client connection.
+    pub async fn accept(&mut self) -> Result<StartHandshake<IO>, rustls::Error> {
+        poll_fn(|cx: &mut Context<'_>| loop {
+            let io = match self.io.as_mut() {
+                Some(io) => io,
+                None => {
+                    return Poll::Ready(Err(rustls::Error::General(
+                        "acceptor cannot be polled after acceptance".into(),
+                    )))
+                }
+            };
+
+            let mut reader = common::SyncReadAdapter { io, cx };
+            match self.acceptor.read_tls(&mut reader) {
+                Ok(0) => return Poll::Ready(Err(rustls::Error::HandshakeNotComplete)),
+                Ok(_) => {}
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => return Poll::Pending,
+                Err(e) => return Poll::Ready(Err(rustls::Error::General(e.to_string()))),
+            }
+
+            match self.acceptor.accept() {
+                Ok(Some(accepted)) => {
+                    let io = self.io.take().unwrap();
+                    return Poll::Ready(Ok(StartHandshake { accepted, io }));
+                }
+                Ok(None) => continue,
+                Err(err) => {
+                    return Poll::Ready(Err(err));
+                }
+            }
+        })
+        .await
+    }
+    /// Takes back the client connection. Will return `None` if called more than once or if the
+    /// connection has been accepted.
+    pub fn take_io(&mut self) -> Option<IO> {
+        self.io.take()
+    }
+}

--- a/tokio-rustls/tests/async_acceptor.rs
+++ b/tokio-rustls/tests/async_acceptor.rs
@@ -1,0 +1,85 @@
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    sync::oneshot,
+};
+use tokio_rustls::{server::AsyncAcceptor, TlsConnector};
+
+#[tokio::test]
+async fn test_async_acceptor_accept() -> Result<(), rustls::Error> {
+    let (sconfig, cconfig) = utils::make_configs();
+    use std::convert::TryFrom;
+
+    let (cstream, sstream) = tokio::io::duplex(1200);
+    let domain = rustls::ServerName::try_from("foobar.com").unwrap();
+
+    tokio::spawn(async move {
+        let connector = crate::TlsConnector::from(cconfig);
+        let mut client = connector.connect(domain, cstream).await.unwrap();
+        client.write_all(b"hello, world!").await.unwrap();
+
+        let mut buf = Vec::new();
+        client.read_to_end(&mut buf).await.unwrap();
+    });
+
+    let mut acceptor = AsyncAcceptor::new(sstream);
+    let start = acceptor.accept().await.unwrap();
+    let ch = start.client_hello();
+
+    assert_eq!(ch.server_name(), Some("foobar.com"));
+    assert_eq!(
+        ch.alpn()
+            .map(|protos| protos.collect::<Vec<_>>())
+            .unwrap_or_default(),
+        Vec::<&[u8]>::new()
+    );
+
+    let mut stream = start.into_stream(sconfig).await.unwrap();
+    let mut buf = [0; 13];
+    stream.read_exact(&mut buf).await.unwrap();
+    assert_eq!(&buf[..], b"hello, world!");
+
+    stream.write_all(b"bye").await.unwrap();
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_async_acceptor_take_io() -> Result<(), rustls::Error> {
+    let (mut cstream, sstream) = tokio::io::duplex(1200);
+
+    let (tx, rx) = oneshot::channel();
+
+    tokio::spawn(async move {
+        cstream.write_all(b"hello, world!").await.unwrap();
+
+        let mut buf = Vec::new();
+        cstream.read_to_end(&mut buf).await.unwrap();
+        tx.send(buf).unwrap();
+    });
+
+    let mut acceptor = AsyncAcceptor::new(sstream);
+    if let Err(err) = acceptor.accept().await {
+        if let rustls::Error::InvalidMessage(_err) = err {
+        } else {
+            panic!("Unexpected Error {:?}", err);
+        }
+    } else {
+        panic!("Expected Err(err)");
+    }
+
+    let server_msg = b"message from server";
+
+    let some_io = acceptor.take_io();
+    assert!(some_io.is_some(), "Expected Some(io)");
+    some_io.unwrap().write_all(server_msg).await.unwrap();
+
+    assert_eq!(rx.await.unwrap(), server_msg);
+
+    assert!(
+        acceptor.take_io().is_none(),
+        "Should not be able to take twice"
+    );
+    Ok(())
+}
+
+// Include `utils` module
+include!("utils.rs");


### PR DESCRIPTION
This is a handle on a server-side connection before configuration is available.  This is a replacement for `LazyConfigAcceptor` which has no way to retrieve the client IO stream after an error.

`AsyncAcceptor` has a function `take_io` which can be used take back ownership of the client IO stream.

An example of this is when a client tries to connect to an TLS socket expecting it to be plain text connection. In this case `take_io` can be used to send a 400 response, "The plain HTTP request was sent to HTTPS port", back to the client.

The reason for a new struct is not break the API of `LazyConfigAcceptor`.