### PR TITLE
generate-certificate.sh: don't assume the location of bash

### DIFF
--- a/tokio-native-tls/scripts/generate-certificate.sh
+++ b/tokio-native-tls/scripts/generate-certificate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 cd $1


### PR DESCRIPTION
The script doesn't need bash, anyway.